### PR TITLE
Add libzmq3-dev to allow garlicoin to build with zmq support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN \
         libevent-dev        \
         bsdmainutils        \
         libboost-all-dev    \
+        libzmq3-dev         \
 		software-properties-common \ 
 	&& add-apt-repository ppa:bitcoin/bitcoin \ 
 	&& apt-get update \


### PR DESCRIPTION
./autogen.sh now outputs

```
checking for ZMQ... yes
```